### PR TITLE
validate config by singbox

### DIFF
--- a/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singb.json
+++ b/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singb.json
@@ -7,7 +7,8 @@
                 "/etc/init.d/singbox-ui-autoupdater": [ "exec" ],
                 "/etc/sing-box/*": ["read"],
                 "/usr/bin/singbox-ui/*": ["exec"],
-                "/tmp/*": ["read"]
+                "/tmp/*": ["read"],
+                "/usr/bin/sing-box check -c /tmp/singbox-config.json": ["exec"]
             },
             "uci": ["singbox-ui"]
         },


### PR DESCRIPTION
Changed JSON validation to validation by calling singbox binary.

This change made to allow use configs with:
- comments
- trailing commas in arrays

As side effect now it also catches misconfigurations, like unknown keys.