### PR TITLE
Fix tproxy firewall rules: avoid double inclusion and handle uci errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Keep OpenWrt shell scripts LF-only to avoid "/bin/sh^M" runtime failures.
+*.sh text eol=lf
+luci-app-singbox-ui/root/usr/bin/singbox-ui/* text eol=lf
+luci-app-singbox-ui/root/etc/init.d/* text eol=lf
+luci-app-singbox-ui/root/etc/uci-defaults/* text eol=lf

--- a/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
+++ b/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
@@ -171,6 +171,16 @@ async function isTproxyUciPresent() {
 	} catch { return false; }
 }
 
+async function setTproxyIncludeEnabled(enabled) {
+	try {
+		if (!(await isTproxyUciPresent())) return;
+		await fs.exec('/sbin/uci', ['set', `firewall.singbox_tproxy.enabled=${enabled ? '1' : '0'}`]);
+		await fs.exec('/sbin/uci', ['commit', 'firewall']);
+	} catch (e) {
+		console.warn('[tproxy] set include enabled failed:', e);
+	}
+}
+
 async function isTunUciPresent() {
 	try {
 		const r = await fs.exec('/sbin/uci', ['get', 'network.proxy.device']);
@@ -179,11 +189,13 @@ async function isTunUciPresent() {
 }
 
 async function disableTproxy() {
+	await setTproxyIncludeEnabled(false);
 	try   { await runNft(['delete', 'table', 'ip', 'singbox']); }
 	catch (e) { console.warn('[tproxy] delete table failed:', e); }
 }
 
 async function enableTproxy() {
+	await setTproxyIncludeEnabled(true);
 	try   { await runNft(['-f', TPROXY_RULE_FILE]); }
 	catch (e) { console.warn('[tproxy] apply rules failed:', e); }
 }
@@ -332,10 +344,9 @@ const MODE_SWITCH_BIN = '/usr/bin/singbox-ui/singbox-ui-mode-switch';
 async function execModeSwitch(action) {
 	const r = await fs.exec(MODE_SWITCH_BIN, [action]);
 	const lines = String(r?.stdout ?? '').trim().split('\n');
-	const lastLine = lines[lines.length - 1].trim();
-	if (lastLine !== 'ok') {
+	const lastLine = lines[lines.length - 1]?.trim();
+	if (lastLine !== 'ok')
 		throw new Error(String(r?.stderr ?? r?.stdout ?? 'mode switch failed').trim() || 'mode switch failed');
-	}
 }
 
 /**
@@ -1302,7 +1313,7 @@ function initPage(page, state, mainContent, mainUrl) {
 								await saveFile('/etc/sing-box/' + currentConfig.name,     '{}');
 								await saveFile('/etc/sing-box/url_' + currentConfig.name, '');
 								if (currentConfig.name === 'config.json') {
-									if (await isTproxyTablePresent()) await disableTproxy();
+									if (state.tproxyActive || await isTproxyTablePresent()) await disableTproxy();
 									await execService('sing-box', 'stop');
 									await execServiceLifecycle('singbox-ui-autoupdater-service', 'stop');
 									await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'stop');

--- a/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
+++ b/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
@@ -7,7 +7,7 @@
 // Constants
 // ============================================================
 
-const TPROXY_RULE_FILE = '/etc/nftables.d/singbox.nft';
+const TPROXY_RULE_FILE = '/etc/sing-box/tproxy.nft';
 const TUN_INTERFACE    = 'singtun0';
 const SINGBOX_BIN      = '/usr/bin/sing-box';
 const UPDATER_BIN      = '/usr/bin/singbox-ui/singbox-ui-updater';

--- a/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
+++ b/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
@@ -3,6 +3,7 @@
 # Actions: enable-tun | disable-tun | enable-tproxy | disable-tproxy
 
 set -e
+ACTION="${1:-unknown}"
 
 NFT_RULE_FILE="/etc/nftables.d/singbox.nft"
 TUN_IFACE="singtun0"
@@ -20,9 +21,14 @@ CROSS='✗'
 
 step()  { echo -e "${INDENT}${ARROW} ${FG_ACCENT}$1${RESET}"; }
 done_() { echo -e "${INDENT}${CHECK} ${FG_SUCCESS}$1${RESET}"; }
-die()   { echo -e "${INDENT}${CROSS} ${FG_ERROR}$1${RESET}" >&2; exit 1; }
 
-trap 'die "Mode switch failed (action: ${1:-unknown})"' ERR
+on_exit() {
+    rc="$?"
+    [ "$rc" -eq 0 ] && return 0
+    echo -e "${INDENT}${CROSS} ${FG_ERROR}Mode switch failed (action: ${ACTION})${RESET}" >&2
+}
+
+trap on_exit EXIT
 
 # ── network.proxy UCI ────────────────────────────────────────────────────────
 
@@ -125,6 +131,8 @@ ensure_tproxy_firewall_include() {
     uci set firewall.singbox_tproxy=include
     uci set firewall.singbox_tproxy.type="nftables"
     uci set firewall.singbox_tproxy.path="$NFT_RULE_FILE"
+    uci set firewall.singbox_tproxy.position="ruleset-prepend"
+    uci -q delete firewall.singbox_tproxy.chain
     uci set firewall.singbox_tproxy.enabled="1"
     uci commit firewall
 }

--- a/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
+++ b/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
@@ -136,7 +136,7 @@ ensure_tproxy_firewall_include() {
     uci set firewall.singbox_tproxy.type="nftables"
     uci set firewall.singbox_tproxy.path="$NFT_RULE_FILE"
     uci set firewall.singbox_tproxy.position="ruleset-prepend"
-    uci -q delete firewall.singbox_tproxy.chain
+    uci -q delete firewall.singbox_tproxy.chain || true
     uci set firewall.singbox_tproxy.enabled="1"
     uci commit firewall
 }

--- a/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
+++ b/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
@@ -5,7 +5,7 @@
 set -e
 ACTION="${1:-unknown}"
 
-NFT_RULE_FILE="/etc/nftables.d/singbox.nft"
+NFT_RULE_FILE="/etc/sing-box/tproxy.nft"
 TUN_IFACE="singtun0"
 
 # ── UI helpers ────────────────────────────────────────────────────────────────
@@ -85,7 +85,7 @@ remove_firewall_tun() {
 # ── nft rules ────────────────────────────────────────────────────────────────
 
 install_nft_rule() {
-    mkdir -p /etc/nftables.d
+    mkdir -p /etc/sing-box
     cat > "$NFT_RULE_FILE" << 'EOF'
 define PROXY_FWMARK = 1
 define BYPASS_MARK = 2
@@ -123,6 +123,10 @@ EOF
 uninstall_nft_rule() {
     nft delete table ip singbox 2>/dev/null || true
     rm -f "$NFT_RULE_FILE"
+}
+
+flush_tproxy_table() {
+    nft delete table ip singbox 2>/dev/null || true
 }
 
 # ── tproxy firewall include ───────────────────────────────────────────────────
@@ -200,6 +204,8 @@ case "$1" in
         install_nft_rule
         step "Configuring firewall include..."
         ensure_tproxy_firewall_include
+        step "Flushing tproxy table for firewall reload..."
+        flush_tproxy_table
         step "Reloading firewall..."
         reload_firewall
         done_ "TPROXY mode enabled"

--- a/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singbox-ui.json
+++ b/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singbox-ui.json
@@ -8,7 +8,6 @@
                 "/etc/init.d/singbox-ui-health-autoupdater-service": ["exec"],
                 "/etc/init.d/singbox-ui-memdoc-service": ["exec"],
                 "/etc/init.d/*": ["read"],
-                "/etc/nftables.d/*": ["read"],
                 "/etc/sing-box/*": ["read"],
                 "/usr/bin/singbox-ui/*": ["exec"],
                 "/sbin/service": ["exec"],
@@ -29,7 +28,6 @@
         "write": {
             "file": {
                 "/etc/sing-box/*": ["write"],
-                "/etc/nftables.d/*": ["write"],
                 "/sbin/uci": ["exec"],
                 "/tmp/*": ["write", "exec"]
             },

--- a/other/scripts/install-singbox.sh
+++ b/other/scripts/install-singbox.sh
@@ -901,7 +901,7 @@ choose_mode() {
 }
 
 definition_mode() {
-    if [ -f /etc/nftables.d/singbox.nft ]; then
+    if [ -f /etc/sing-box/tproxy.nft ]; then
         show_progress "$MSG_MODE_FOUND_TPROXY"
         MODE=2
     elif uci -q get network.proxy.device | grep -q "singtun0"; then


### PR DESCRIPTION
Closes #71

This PR addresses the nftables syntax errors and firewall restart failures in TProxy mode after reboot.

**Changes:**
1. Moved TProxy nft rules: Rules are no longer placed in `/etc/nftables.d/` to prevent double inclusion by `fw4`, which caused syntax errors.
2. Fixed `uci delete` error: Suppressed non-zero exit code in `ensure_tproxy_firewall_include` to prevent script abortion when the config entry doesn't exist yet.

Tested on OpenWrt 25.12.1.

@ang3el7z Please review. I'm marking this as ready for review, but feel free to request changes if further testing is needed.