### PR TITLE
refactor: make nftables rules idempotent

### DIFF
--- a/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
+++ b/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
@@ -87,6 +87,9 @@ remove_firewall_tun() {
 install_nft_rule() {
     mkdir -p /etc/sing-box
     cat > "$NFT_RULE_FILE" << 'EOF'
+table ip singbox {}
+delete table ip singbox
+
 define PROXY_FWMARK = 1
 define BYPASS_MARK = 2
 define RESERVED_IP = {


### PR DESCRIPTION
Make tproxy.nft idempotent
- Add `table ip singbox {}` and `delete table ip singbox` before main rules
- Prevents duplicate rules on repeated `nft -f` execution