### PR TITLE
feat(tproxy): add persistent policy routing and sysctl configuration

### DIFF
--- a/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
+++ b/luci-app-singbox-ui/root/usr/bin/singbox-ui/singbox-ui-mode-switch
@@ -6,6 +6,7 @@ set -e
 ACTION="${1:-unknown}"
 
 NFT_RULE_FILE="/etc/sing-box/tproxy.nft"
+SYSCTL_CONF_FILE="/etc/sysctl.d/99-singbox-tproxy.conf"
 TUN_IFACE="singtun0"
 
 # ── UI helpers ────────────────────────────────────────────────────────────────
@@ -149,16 +150,57 @@ remove_tproxy_firewall_include() {
     uci commit firewall
 }
 
+# ── sysctl for tproxy ──────────────────────────────────────────────────────
+
+install_sysctl_config() {
+    for iface in /proc/sys/net/ipv4/conf/*/route_localnet; do
+        echo 1 > "$iface" 2>/dev/null || true
+    done
+
+    mkdir -p /etc/sysctl.d
+    cat > "$SYSCTL_CONF_FILE" << 'EOF'
+net.ipv4.conf.all.route_localnet=1
+net.ipv4.conf.default.route_localnet=1
+EOF
+    sysctl -p "$SYSCTL_CONF_FILE" >/dev/null 2>&1 || true
+}
+
+uninstall_sysctl_config() {
+    for iface in /proc/sys/net/ipv4/conf/*/route_localnet; do
+        echo 0 > "$iface" 2>/dev/null || true
+    done
+
+    rm -f "$SYSCTL_CONF_FILE"
+}
+
 # ── policy routing for tproxy ────────────────────────────────────────────────
 
 setup_tproxy_routing() {
     ip rule add fwmark 1 table 100 2>/dev/null || true
     ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null || true
+
+    uci set network.singbox_tproxy_rule=rule
+    uci set network.singbox_tproxy_rule.mark='0x1'
+    uci set network.singbox_tproxy_rule.lookup='100'
+    uci set network.singbox_tproxy_rule.priority='100'
+
+    uci set network.singbox_tproxy_route=route
+    uci set network.singbox_tproxy_route.interface='loopback'
+    uci set network.singbox_tproxy_route.target='0.0.0.0'
+    uci set network.singbox_tproxy_route.netmask='0.0.0.0'
+    uci set network.singbox_tproxy_route.table='100'
+    uci set network.singbox_tproxy_route.type='local'
+
+    uci commit network
 }
 
 cleanup_tproxy_routing() {
     ip rule del fwmark 1 table 100 2>/dev/null || true
     ip route flush table 100 2>/dev/null || true
+
+    uci -q delete network.singbox_tproxy_rule
+    uci -q delete network.singbox_tproxy_route
+    uci commit network
 }
 
 # ── service helpers ──────────────────────────────────────────────────────────
@@ -203,6 +245,8 @@ case "$1" in
     enable-tproxy)
         step "Setting up policy routing..."
         setup_tproxy_routing
+        step "Installing sysctl config..."
+        install_sysctl_config
         step "Installing nftables rule..."
         install_nft_rule
         step "Configuring firewall include..."
@@ -223,6 +267,8 @@ case "$1" in
         uninstall_nft_rule
         step "Cleaning up policy routing..."
         cleanup_tproxy_routing
+        step "Uninstalling sysctl config..."
+        uninstall_sysctl_config
         done_ "TPROXY mode disabled"
         echo "ok"
         ;;


### PR DESCRIPTION
Added UCI persistence for TProxy routing rules (fwmark 1 → table 100 + local route) and persistent sysctl configuration for route_localnet=1 across all interfaces. Previously, both were lost after reboot.