### PR TITLE
feat: add i18n support and fix ACL/menu issues

### DIFF
--- a/luci-app-singbox-ui/Makefile
+++ b/luci-app-singbox-ui/Makefile
@@ -7,12 +7,8 @@ PKG_RELEASE:=1
 LUCI_TITLE:=LuCI singbox-ui app
 LUCI_DEPENDS:=+luci-base +sing-box +curl +jq
 LUCI_PKGARCH:=all
-LUCI_LANG.ru:=Русский (Russian)
-LUCI_LANG.en:=English
-
 PKG_LICENSE:=GPL-2.0-only
 PKG_MAINTAINER:=Ang3el <singboxui@ang3el.world>
-LUCI_LANGUAGES:=en ru
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
+++ b/luci-app-singbox-ui/htdocs/luci-static/resources/view/singbox-ui/singbox-ui.js
@@ -2,6 +2,7 @@
 'require view';
 'require ui';
 'require fs';
+'require rpc';
 
 // ============================================================
 // Constants
@@ -16,9 +17,9 @@ const UCI_SECTION      = 'main';
 const ACE_BASE         = '/luci-static/resources/view/singbox-ui/ace/';
 
 const CONFIGS = [
-	{ name: 'config.json',  label: 'Main Config #1' },
-	{ name: 'config2.json', label: 'Backup Config #2' },
-	{ name: 'config3.json', label: 'Backup Config #3' },
+	{ name: 'config.json',  label: _('Main Config #1') },
+	{ name: 'config2.json', label: _('Backup Config #2') },
+	{ name: 'config3.json', label: _('Backup Config #3') },
 ];
 
 // ============================================================
@@ -295,10 +296,10 @@ async function isValidConfig(content) {
 		if (r.code === 0) return true;
 		let msg = String(r.stderr || '').trim();
 		if (msg.includes(tmp)) msg = msg.substring(msg.indexOf(tmp) + tmp.length + 1).trim();
-		notify('error', 'Config error: ' + (msg || 'validation failed'));
+		notify('error', _('Config error: ') + (msg || _('validation failed')));
 		return false;
 	} catch (e) {
-		notify('error', 'Validation error: ' + e.message);
+		notify('error', _('Validation error: ') + e.message);
 		return false;
 	} finally {
 		try { await fs.remove(tmp); } catch (_) {}
@@ -314,12 +315,12 @@ async function formatConfig(content) {
 		if (r.code !== 0) {
 			let msg = String(r.stderr || r.stdout || '').trim();
 			if (msg.includes(tmp)) msg = msg.substring(msg.indexOf(tmp) + tmp.length + 1).trim();
-			notify('error', 'Format failed: ' + (msg || 'unknown error'));
+			notify('error', _('Format failed: ') + (msg || _('unknown error')));
 			return null;
 		}
 		return await loadFile(tmp);
 	} catch (e) {
-		notify('error', 'Format error: ' + e.message);
+		notify('error', _('Format error: ') + e.message);
 		return null;
 	} finally {
 		try { await fs.remove(tmp); } catch (_) {}
@@ -434,7 +435,7 @@ function showModeModal(options) {
   <div class="sbox-modal-body">${options.body}</div>
   <div class="sbox-modal-actions">
     ${btns}
-    <button type="button" class="cbi-button cbi-button-neutral" data-cancel>Cancel</button>
+    <button type="button" class="cbi-button cbi-button-neutral" data-cancel>${_('Cancel')}</button>
   </div>
 </div>`;
 
@@ -843,15 +844,15 @@ function buildControlInner(state) {
 	const sk = state.singboxRunning
 		? 'running'
 		: (state.singboxStatus === 'error' ? 'error' : 'inactive');
-	const statusLabel = sk === 'running' ? 'Running' : (sk === 'error' ? 'Error' : 'Inactive');
+	const statusLabel = sk === 'running' ? _('Running') : (sk === 'error' ? _('Error') : _('Inactive'));
 
 	const btn = (cls, action, label, title) =>
 		`<button type="button" class="cbi-button cbi-button-${cls}" data-action="${action}"${title ? ` title="${title}"` : ''}>${label}</button>`;
 
 	const svcLabel = () => {
-		if (state.healthAutoupdaterServiceTempFlag) return 'Sing-Box & Health Autoupdater';
-		if (state.autoupdaterServiceTempFlag)       return 'Sing-Box & Autoupdater';
-		return 'Sing-Box';
+		if (state.healthAutoupdaterServiceTempFlag) return _('Sing-Box & Health Autoupdater');
+		if (state.autoupdaterServiceTempFlag)       return _('Sing-Box & Autoupdater');
+		return _('Sing-Box');
 	};
 
 	const ctrlBtns = [
@@ -859,11 +860,11 @@ function buildControlInner(state) {
 			? btn(
 				state.singboxRunning ? 'remove' : 'apply',
 				'startStop',
-				state.singboxRunning ? 'Stop' : 'Start',
-				(state.singboxRunning ? 'Stop ' : 'Start ') + svcLabel())
+				state.singboxRunning ? _('Stop') : _('Start'),
+				(state.singboxRunning ? _('Stop ') : _('Start ')) + svcLabel())
 			: '',
 		state.singboxRunning && state.isInitialConfigValid
-			? btn('reload', 'restart', 'Restart') : '',
+			? btn('reload', 'restart', _('Restart')) : '',
 	].filter(Boolean).join('');
 
 	return `
@@ -884,27 +885,27 @@ function buildServiceInner(state) {
 			? btn(
 				state.autoupdaterEnabled ? 'negative' : 'positive',
 				'toggleAutoupdater',
-				state.autoupdaterEnabled ? 'Stop Autoupdater' : 'Autoupdater',
+				state.autoupdaterEnabled ? _('Stop Autoupdater') : _('Autoupdater'),
 				state.autoupdaterEnabled
-					? 'Stop periodic config update from subscription URL'
-					: 'Start periodic config update from subscription URL')
+					? _('Stop periodic config update from subscription URL')
+					: _('Start periodic config update from subscription URL'))
 			: '',
 		state.mainConfigHasUrl && !state.autoupdaterEnabled
 			? btn(
 				state.healthAutoupdaterEnabled ? 'negative' : 'positive',
 				'toggleHealthAutoupdater',
-				state.healthAutoupdaterEnabled ? 'Stop Health Autoupdater' : 'Health Autoupdater',
+				state.healthAutoupdaterEnabled ? _('Stop Health Autoupdater') : _('Health Autoupdater'),
 				state.healthAutoupdaterEnabled
-					? 'Stop config update on outbound health failure'
-					: 'Update config when outbound health check fails')
+					? _('Stop config update on outbound health failure')
+					: _('Update config when outbound health check fails'))
 			: '',
 		btn(
 			state.memdocEnabled ? 'negative' : 'positive',
 			'toggleMemdoc',
-			state.memdocEnabled ? 'Stop Memdoc' : 'Memdoc',
+			state.memdocEnabled ? _('Stop Memdoc') : _('Memdoc'),
 			state.memdocEnabled
-				? 'Stop memory monitor'
-				: 'Restart sing-box when free RAM is low'),
+				? _('Stop memory monitor')
+				: _('Restart sing-box when free RAM is low')),
 	].filter(Boolean).join('');
 
 	return `
@@ -914,12 +915,12 @@ function buildServiceInner(state) {
 function buildSettingsInner(state) {
 	const enabled = !!state.autoHideNotificationEnabled;
 	const cls     = enabled ? 'positive' : 'negative';
-	const label   = 'Auto Hide Notif';
+	const label   = _('Auto Hide Notif');
 
 	return `
   <div class="sbox-row">
     <button type="button" class="cbi-button cbi-button-${cls}" data-action="toggleAutoHideNotification">${label}</button>
-    <span class="sbox-muted">Success: 6s, Error: 10s</span>
+    <span class="sbox-muted">${_('Success: 6s, Error: 10s')}</span>
   </div>`;
 }
 
@@ -940,17 +941,17 @@ function buildPageHtml(state) {
   sing-box <strong>${v.singbox}</strong>
   ${dot}
   <span id="sbox-mode-badge" class="sbox-header-mode${proxyMode === 'conflict' ? ' sbox-header-mode-conflict' : ''}${proxyMode !== 'custom' ? ' sbox-header-mode-btn' : ''}" data-mode="${proxyMode}">${
-		proxyMode === 'custom'   ? 'custom setup' :
-		proxyMode === 'conflict' ? '\u26A0 fix: tproxy + tun conflict' :
-		proxyMode + ' mode'
+		proxyMode === 'custom'   ? _('custom setup') :
+		proxyMode === 'conflict' ? '\u26A0 ' + _('fix: tproxy + tun conflict') :
+		proxyMode + ' ' + _('mode')
 	}</span>
-  <button type="button" id="sbox-header-dash" class="cbi-button cbi-button-apply sbox-header-dash"${(state.singboxRunning && state.dashboardPort) ? '' : ' style="display:none"'}>Dashboard</button>
+  <button type="button" id="sbox-header-dash" class="cbi-button cbi-button-apply sbox-header-dash"${(state.singboxRunning && state.dashboardPort) ? '' : ' style="display:none"'}>${_('Dashboard')}</button>
 </div>
 <div class="sbox-card" id="sbox-ctrl-svc">
   <div class="sbox-card-tabs">
-    <button type="button" class="sbox-tab sbox-tab-active" data-tab="control">Control</button>
-    <button type="button" class="sbox-tab" data-tab="services">Services</button>
-    <button type="button" class="sbox-tab" data-tab="settings">Settings</button>
+    <button type="button" class="sbox-tab sbox-tab-active" data-tab="control">${_('Control')}</button>
+    <button type="button" class="sbox-tab" data-tab="services">${_('Services')}</button>
+    <button type="button" class="sbox-tab" data-tab="settings">${_('Settings')}</button>
   </div>
   <div id="sbox-tab-control">${buildControlInner(state)}</div>
   <div id="sbox-tab-services" style="display:none">${buildServiceInner(state)}</div>
@@ -958,23 +959,23 @@ function buildPageHtml(state) {
 </div>
 <div class="sbox-card" id="sbox-config">
   <div class="sbox-card-tabs">
-    <button type="button" class="sbox-tab sbox-tab-active" data-tab="config">Config</button>
-    <button type="button" class="sbox-tab" data-tab="logs">Logs</button>
+    <button type="button" class="sbox-tab sbox-tab-active" data-tab="config">${_('Config')}</button>
+    <button type="button" class="sbox-tab" data-tab="logs">${_('Logs')}</button>
   </div>
   <div id="sbox-tab-config">
     <div class="sbox-cfg-top">
       <select id="sbox-config-select" class="sbox-select">${opts}</select>
-      <input type="url" id="sbox-url" class="sbox-input" placeholder="Subscription URL: https://\u2026" />
-      ${cbtn('positive', 'saveUrl', 'Save URL')}
-      ${cbtn('reload',   'update',  'Update')}
+      <input type="url" id="sbox-url" class="sbox-input" placeholder="${_('Subscription URL')}: https://\u2026" />
+      ${cbtn('positive', 'saveUrl', _('Save URL'))}
+      ${cbtn('reload',   'update',  _('Update'))}
     </div>
     <div id="sbox-ace" class="sbox-editor"></div>
     <div class="sbox-actions">
-      ${cbtn('apply',    'format',   'Format')}
-      ${cbtn('positive', 'save',     'Save')}
+      ${cbtn('apply',    'format',   _('Format'))}
+      ${cbtn('positive', 'save',     _('Save'))}
       <button type="button" class="cbi-button cbi-button-apply"
-        data-config-action="setAsMain" id="sbox-set-main-btn" style="display:none">Set as Main</button>
-      ${cbtn('negative', 'clear', 'Clear All')}
+        data-config-action="setAsMain" id="sbox-set-main-btn" style="display:none">${_('Set as Main')}</button>
+      ${cbtn('negative', 'clear', _('Clear All'))}
     </div>
   </div>
   <div id="sbox-tab-logs" style="display:none">
@@ -983,7 +984,7 @@ function buildPageHtml(state) {
     </div>
     <div class="sbox-log-viewer">
       <pre id="sbox-log-content" class="sbox-log-content"></pre>
-      <button type="button" class="sbox-log-scroll-btn" id="sbox-log-scroll-btn" title="Scroll to bottom">\u2193 Bottom</button>
+      <button type="button" class="sbox-log-scroll-btn" id="sbox-log-scroll-btn" title="${_('Scroll to bottom')}">\u2193 ${_('Bottom')}</button>
     </div>
   </div>
 </div>`;
@@ -1035,7 +1036,7 @@ function initPage(page, state, mainContent, mainUrl) {
 								await execServiceLifecycle('singbox-ui-autoupdater-service', 'stop');
 							else if (state.healthAutoupdaterServiceTempFlag)
 								await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'stop');
-							notify('info', 'Sing-Box stopped');
+							notify('info', _('Sing-Box stopped'));
 						} else {
 							await execService('sing-box', 'start');
 							if (state.tproxyActive) await enableTproxy();
@@ -1043,10 +1044,10 @@ function initPage(page, state, mainContent, mainUrl) {
 								await execServiceLifecycle('singbox-ui-autoupdater-service', 'start');
 							else if (state.healthAutoupdaterServiceTempFlag)
 								await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'start');
-							notify('info', 'Sing-Box started');
+							notify('info', _('Sing-Box started'));
 						}
 					} catch (e) {
-						notify('error', 'Operation failed: ' + e.message);
+						notify('error', _('Operation failed: ') + e.message);
 					}
 					await refreshControlCard();
 				});
@@ -1060,9 +1061,9 @@ function initPage(page, state, mainContent, mainUrl) {
 							await execServiceLifecycle('singbox-ui-autoupdater-service', 'restart');
 						else if (state.healthAutoupdaterServiceTempFlag)
 							await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'restart');
-						notify('info', 'Sing-Box restarted');
+						notify('info', _('Sing-Box restarted'));
 					} catch (e) {
-						notify('error', 'Restart failed: ' + e.message);
+						notify('error', _('Restart failed: ') + e.message);
 					}
 					await refreshControlCard();
 				});
@@ -1128,15 +1129,15 @@ function initPage(page, state, mainContent, mainUrl) {
 						if (state.autoupdaterEnabled) {
 							await execServiceLifecycle('singbox-ui-autoupdater-service', 'stop');
 							await writeUciFlag('autoupdater_service_state', false);
-							notify('info', 'Autoupdater stopped');
+							notify('info', _('Autoupdater stopped'));
 						} else {
 							await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'stop');
 							await writeUciFlag('health_autoupdater_service_state', false);
 							await writeUciFlag('autoupdater_service_state', true);
 							await execServiceLifecycle('singbox-ui-autoupdater-service', 'start');
-							notify('info', 'Autoupdater started');
+							notify('info', _('Autoupdater started'));
 						}
-					} catch (e) { notify('error', 'Toggle failed: ' + e.message); }
+					} catch (e) { notify('error', _('Toggle failed: ') + e.message); }
 					await refreshServiceCard();
 				});
 			},
@@ -1147,15 +1148,15 @@ function initPage(page, state, mainContent, mainUrl) {
 						if (state.healthAutoupdaterEnabled) {
 							await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'stop');
 							await writeUciFlag('health_autoupdater_service_state', false);
-							notify('info', 'Health Autoupdater stopped');
+							notify('info', _('Health Autoupdater stopped'));
 						} else {
 							await execServiceLifecycle('singbox-ui-autoupdater-service', 'stop');
 							await writeUciFlag('autoupdater_service_state', false);
 							await writeUciFlag('health_autoupdater_service_state', true);
 							await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'start');
-							notify('info', 'Health Autoupdater started');
+							notify('info', _('Health Autoupdater started'));
 						}
-					} catch (e) { notify('error', 'Toggle failed: ' + e.message); }
+					} catch (e) { notify('error', _('Toggle failed: ') + e.message); }
 					await refreshServiceCard();
 				});
 			},
@@ -1165,12 +1166,12 @@ function initPage(page, state, mainContent, mainUrl) {
 					try {
 						if (state.memdocEnabled) {
 							await execServiceLifecycle('singbox-ui-memdoc-service', 'stop');
-							notify('info', 'Memdoc stopped');
+							notify('info', _('Memdoc stopped'));
 						} else {
 							await execServiceLifecycle('singbox-ui-memdoc-service', 'start');
-							notify('info', 'Memdoc started');
+							notify('info', _('Memdoc started'));
 						}
-					} catch (e) { notify('error', 'Toggle failed: ' + e.message); }
+					} catch (e) { notify('error', _('Toggle failed: ') + e.message); }
 					await refreshServiceCard();
 				});
 			},
@@ -1204,9 +1205,9 @@ function initPage(page, state, mainContent, mainUrl) {
 						state.autoHideNotificationEnabled = !state.autoHideNotificationEnabled;
 						autoHideNotificationEnabled = state.autoHideNotificationEnabled;
 						await writeUciFlag('autohide_notification_state', state.autoHideNotificationEnabled);
-						notify('info', 'Auto hide notifications ' + (state.autoHideNotificationEnabled ? 'enabled' : 'disabled'));
+						notify('info', _('Auto hide notifications ') + (state.autoHideNotificationEnabled ? _('enabled') : _('disabled')));
 					} catch (e) {
-						notify('error', 'Settings update failed: ' + e.message);
+						notify('error', _('Settings update failed: ') + e.message);
 					}
 					await refreshSettingsCard();
 				});
@@ -1228,37 +1229,37 @@ function initPage(page, state, mainContent, mainUrl) {
 	const configActions = {
 		async saveUrl(b) {
 			const url = urlEl?.value.trim() || '';
-			if (!url)             return notify('error', 'URL is empty');
-			if (!isValidUrl(url)) return notify('error', 'Invalid URL');
+			if (!url)             return notify('error', _('URL is empty'));
+			if (!isValidUrl(url)) return notify('error', _('Invalid URL'));
 			await withButtons(b, async () => {
 				try {
 					await saveFile('/etc/sing-box/url_' + currentConfig.name, url);
-					notify('info', 'URL saved');
+					notify('info', _('URL saved'));
 					const r = await fs.exec(UPDATER_BIN, [
 						'/etc/sing-box/url_' + currentConfig.name,
 						'/etc/sing-box/' + currentConfig.name,
 					]);
 					if (r.code === 2) {
-						notify('info', 'No changes detected');
+						notify('info', _('No changes detected'));
 					} else if (r.code !== 0) {
-						notify('error', r.stderr || r.stdout || 'Update failed');
+						notify('error', r.stderr || r.stdout || _('Update failed'));
 					} else {
 						const newContent = await loadFile('/etc/sing-box/' + currentConfig.name);
 						const ed = window.singboxEditor;
 						if (ed) { ed.setValue(newContent, -1); ed.clearSelection(); }
-						notify('info', currentConfig.label + ' updated');
-				if (currentConfig.name === 'config.json') {
-						await execService('sing-box', 'reload');
-						notify('info', 'Sing-Box reloaded');
-						state.isInitialConfigValid = await isValidConfig(newContent);
-						state.mainConfigHasUrl = true;
-						state.dashboardPort = parseDashboardPort(newContent);
-						await refreshControlCard();
-						await refreshServiceCard();
-					}
+						notify('info', currentConfig.label + ' ' + _('updated'));
+						if (currentConfig.name === 'config.json') {
+							await execService('sing-box', 'reload');
+							notify('info', _('Sing-Box reloaded'));
+							state.isInitialConfigValid = await isValidConfig(newContent);
+							state.mainConfigHasUrl = true;
+							state.dashboardPort = parseDashboardPort(newContent);
+							await refreshControlCard();
+							await refreshServiceCard();
+						}
 					}
 				} catch (e) {
-					notify('error', 'Save URL failed: ' + e.message);
+					notify('error', _('Save URL failed: ') + e.message);
 				}
 			});
 		},
@@ -1270,41 +1271,43 @@ function initPage(page, state, mainContent, mainUrl) {
 						'/etc/sing-box/url_' + currentConfig.name,
 						'/etc/sing-box/' + currentConfig.name,
 					]);
-					if (r.code === 2) return notify('info', 'No changes detected');
-					if (r.code !== 0) return notify('error', r.stderr || r.stdout || 'Update failed');
+					if (r.code === 2) return notify('info', _('No changes detected'));
+					if (r.code !== 0) return notify('error', r.stderr || r.stdout || _('Update failed'));
 					const newContent = await loadFile('/etc/sing-box/' + currentConfig.name);
 					const ed = window.singboxEditor;
 					if (ed) { ed.setValue(newContent, -1); ed.clearSelection(); }
-					notify('info', currentConfig.label + ' updated');
+					notify('info', _('Config updated'));
 					if (currentConfig.name === 'config.json') {
 						await execService('sing-box', 'reload');
-						notify('info', 'Sing-Box reloaded');
+						notify('info', _('Sing-Box reloaded'));
 						state.isInitialConfigValid = await isValidConfig(newContent);
 						state.dashboardPort = parseDashboardPort(newContent);
 						await refreshControlCard();
 					}
-				} catch (e) { notify('error', 'Update failed: ' + e.message); }
+				} catch (e) {
+					notify('error', _('Update failed: ') + e.message);
+				}
 			});
 		},
 
 		format(b) {
 			const ed = window.singboxEditor;
-			if (!ed) return notify('error', 'Editor not ready');
+			if (!ed) return notify('error', _('Editor not ready'));
 			const val = ed.getValue();
-			if (!val?.trim()) return notify('info', 'Nothing to format');
+			if (!val?.trim()) return notify('info', _('Nothing to format'));
 
 			const applyFormatted = async (formatted) => {
 				if (formatted != null) {
 					ed.setValue(formatted, -1);
 					ed.clearSelection();
-					notify('info', 'Formatted');
+					notify('info', _('Formatted'));
 				}
 			};
 
 			showModeModal({
-				title: 'Format config',
-				body: '<b>sing-box</b> — validates and reorders keys per schema.<br>'
-				    + '<b>JSON5</b> — fixes indentation, preserves comments and key order.',
+				title: _('Format config'),
+				body: '<b>sing-box</b> — ' + _('validates and reorders keys per schema.') + '<br>'
+				    + '<b>JSON5</b> — ' + _('fixes indentation, preserves comments and key order.'),
 				buttons: [
 					{
 						cls: 'apply', label: 'sing-box',
@@ -1326,20 +1329,20 @@ function initPage(page, state, mainContent, mainUrl) {
 			const ed = window.singboxEditor;
 			if (!ed) return;
 			const val = ed.getValue();
-			if (!val) return notify('error', 'Config is empty');
+			if (!val) return notify('error', _('Config is empty'));
 			await withButtons(b, async () => {
 				try {
 					if (!(await isValidConfig(val))) return;
 					await saveFile('/etc/sing-box/' + currentConfig.name, val);
-					notify('info', 'Config saved');
+					notify('info', _('Config saved'));
 					if (currentConfig.name === 'config.json') {
 						await execService('sing-box', 'reload');
-						notify('info', 'Sing-Box reloaded');
+						notify('info', _('Sing-Box reloaded'));
 						state.isInitialConfigValid = true;
 						state.dashboardPort = parseDashboardPort(val);
 						await refreshControlCard();
 					}
-				} catch (e) { notify('error', 'Save failed: ' + e.message); }
+				} catch (e) { notify('error', _('Save failed: ') + e.message); }
 			});
 		},
 
@@ -1358,9 +1361,9 @@ function initPage(page, state, mainContent, mainUrl) {
 					await saveFile('/etc/sing-box/url_config.json',           nu);
 					await saveFile('/etc/sing-box/url_' + currentConfig.name, ou);
 					await execService('sing-box', 'reload');
-					notify('info', currentConfig.label + ' is now main config');
+					notify('info', currentConfig.label + ' ' + _('is now main config'));
 				} catch (e) {
-					notify('error', 'Set as main failed: ' + e.message);
+					notify('error', _('Set as main failed: ') + e.message);
 				} finally {
 					reloadPage();
 				}
@@ -1369,10 +1372,10 @@ function initPage(page, state, mainContent, mainUrl) {
 
 		clear(b) {
 			showModeModal({
-				title: 'Clear all data?',
-				body:  `Config and URL for <b>${currentConfig.label}</b> will be erased.<br>This cannot be undone.`,
+				title: _('Clear all data?'),
+				body:  _('Config and URL for') + ` <b>${currentConfig.label}</b> ` + _('will be erased.') + '<br>' + _('This cannot be undone.'),
 				buttons: [{
-					cls: 'remove', label: 'Clear',
+					cls: 'remove', label: _('Clear'),
 					action: async () => {
 						await withButtons(b, async () => {
 							try {
@@ -1383,12 +1386,12 @@ function initPage(page, state, mainContent, mainUrl) {
 									await execService('sing-box', 'stop');
 									await execServiceLifecycle('singbox-ui-autoupdater-service', 'stop');
 									await execServiceLifecycle('singbox-ui-health-autoupdater-service', 'stop');
-									notify('info', 'Config cleared, services stopped');
+									notify('info', _('Config cleared, services stopped'));
 								} else {
-									notify('info', currentConfig.label + ' cleared');
+									notify('info', currentConfig.label + ' ' + _('cleared'));
 								}
 							} catch (e) {
-								notify('error', 'Clear failed: ' + e.message);
+								notify('error', _('Clear failed: ') + e.message);
 							} finally {
 								reloadPage();
 							}
@@ -1438,46 +1441,46 @@ function initPage(page, state, mainContent, mainUrl) {
 		const mode = modeBadge.dataset.mode;
 
 		const switchTo = async (disable, enable) => {
-			notify('info', 'Switching mode\u2026');
+			notify('info', _('Switching mode\u2026'));
 			try {
 				if (disable) await execModeSwitch(disable);
 				if (enable)  await execModeSwitch(enable);
-				notify('info', 'Mode switched, reloading\u2026');
+				notify('info', _('Mode switched, reloading\u2026'));
 				reloadPage(1200);
 			} catch (e) {
-				notify('error', 'Mode switch failed: ' + e.message);
+				notify('error', _('Mode switch failed: ') + e.message);
 			}
 		};
 
 		if (mode === 'tun') {
 			modeBadge.onclick = () => showModeModal({
-				title: 'Switch to tproxy mode?',
-				body:  'tun interface <b>singtun0</b> will be removed.<br>tproxy nft rules and policy routing will be applied.',
+				title: _('Switch to tproxy mode?'),
+				body:  _('tun interface') + ' <b>singtun0</b> ' + _('will be removed.') + '<br>' + _('tproxy nft rules and policy routing will be applied.'),
 				buttons: [{
-					cls: 'apply', label: 'Switch to tproxy',
+					cls: 'apply', label: _('Switch to tproxy'),
 					action: () => switchTo('disable-tun', 'enable-tproxy'),
 				}],
 			});
 		} else if (mode === 'tproxy') {
 			modeBadge.onclick = () => showModeModal({
-				title: 'Switch to tun mode?',
-				body:  'tproxy nft rules will be removed.<br>tun interface <b>singtun0</b> and firewall zone will be configured.',
+				title: _('Switch to tun mode?'),
+				body:  _('tproxy nft rules will be removed.') + '<br>' + _('tun interface') + ' <b>singtun0</b> ' + _('and firewall zone will be configured.'),
 				buttons: [{
-					cls: 'apply', label: 'Switch to tun',
+					cls: 'apply', label: _('Switch to tun'),
 					action: () => switchTo('disable-tproxy', 'enable-tun'),
 				}],
 			});
 		} else if (mode === 'conflict') {
 			modeBadge.onclick = () => showModeModal({
-				title: '\u26A0 Conflict: tproxy + tun both active',
-				body:  'Both modes are active simultaneously. Disable one to resolve:',
+				title: '\u26A0 ' + _('Conflict: tproxy + tun both active'),
+				body:  _('Both modes are active simultaneously. Disable one to resolve:'),
 				buttons: [
 					{
-						cls: 'apply', label: 'Keep tproxy (disable tun)',
+						cls: 'apply', label: _('Keep tproxy (disable tun)'),
 						action: () => switchTo('disable-tun', null),
 					},
 					{
-						cls: 'reload', label: 'Keep tun (disable tproxy)',
+						cls: 'reload', label: _('Keep tun (disable tproxy)'),
 						action: () => switchTo('disable-tproxy', null),
 					},
 				],
@@ -1541,7 +1544,7 @@ function initPage(page, state, mainContent, mainUrl) {
 			if (logContent) logContent.innerHTML = colorizeLog(raw);
 			if (logUpdated) {
 				const t = new Date();
-				logUpdated.textContent = `Updated ${t.getHours().toString().padStart(2,'0')}:${t.getMinutes().toString().padStart(2,'0')}:${t.getSeconds().toString().padStart(2,'0')}`;
+				logUpdated.textContent = _('Updated') + ' ' + `${t.getHours().toString().padStart(2,'0')}:${t.getMinutes().toString().padStart(2,'0')}:${t.getSeconds().toString().padStart(2,'0')}`;
 			}
 		} catch (_) {}
 		if (atBottom && logContent) logContent.scrollTop = logContent.scrollHeight;
@@ -1597,7 +1600,7 @@ function initPage(page, state, mainContent, mainUrl) {
 	if (aceEl) {
 		initAceEditor(aceEl, mainContent).catch(e => {
 			console.error('[singbox-ui] Ace init error:', e);
-			notify('error', 'Editor failed to load: ' + e.message);
+			notify('error', _('Editor failed to load: ') + e.message);
 		});
 	}
 }
@@ -1669,7 +1672,7 @@ return view.extend({
 				initPage(page, state, mainContent, mainUrl);
 			} catch (e) {
 				console.error('[singbox-ui] initPage error:', e);
-				notify('error', 'Page init failed: ' + e.message);
+				notify('error', _('Page init failed: ') + e.message);
 			}
 		}, 50);
 

--- a/luci-app-singbox-ui/po/en/singbox-ui.po
+++ b/luci-app-singbox-ui/po/en/singbox-ui.po
@@ -1,0 +1,355 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Main Config #1"
+msgstr ""
+
+msgid "Backup Config #2"
+msgstr ""
+
+msgid "Backup Config #3"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Stop"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "Stop "
+msgstr ""
+
+msgid "Start "
+msgstr ""
+
+msgid "Sing-Box & Health Autoupdater"
+msgstr ""
+
+msgid "Sing-Box & Autoupdater"
+msgstr ""
+
+msgid "Sing-Box"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Stop Autoupdater"
+msgstr ""
+
+msgid "Autoupdater"
+msgstr ""
+
+msgid "Stop periodic config update from subscription URL"
+msgstr ""
+
+msgid "Start periodic config update from subscription URL"
+msgstr ""
+
+msgid "Stop Health Autoupdater"
+msgstr ""
+
+msgid "Health Autoupdater"
+msgstr ""
+
+msgid "Stop config update on outbound health failure"
+msgstr ""
+
+msgid "Update config when outbound health check fails"
+msgstr ""
+
+msgid "Stop Memdoc"
+msgstr ""
+
+msgid "Memdoc"
+msgstr ""
+
+msgid "Stop memory monitor"
+msgstr ""
+
+msgid "Restart sing-box when free RAM is low"
+msgstr ""
+
+msgid "Auto Hide Notif"
+msgstr ""
+
+msgid "Success: 6s, Error: 10s"
+msgstr ""
+
+msgid "custom setup"
+msgstr ""
+
+msgid "fix: tproxy + tun conflict"
+msgstr ""
+
+msgid "mode"
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "Control"
+msgstr ""
+
+msgid "Services"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Config"
+msgstr ""
+
+msgid "Logs"
+msgstr ""
+
+msgid "Subscription URL"
+msgstr ""
+
+msgid "Save URL"
+msgstr ""
+
+msgid "Update"
+msgstr ""
+
+msgid "Format"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Set as Main"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
+msgid "Scroll to bottom"
+msgstr ""
+
+msgid "Bottom"
+msgstr ""
+
+msgid "Sing-Box stopped"
+msgstr ""
+
+msgid "Sing-Box started"
+msgstr ""
+
+msgid "Operation failed: "
+msgstr ""
+
+msgid "Sing-Box restarted"
+msgstr ""
+
+msgid "Restart failed: "
+msgstr ""
+
+msgid "Autoupdater stopped"
+msgstr ""
+
+msgid "Autoupdater started"
+msgstr ""
+
+msgid "Health Autoupdater stopped"
+msgstr ""
+
+msgid "Health Autoupdater started"
+msgstr ""
+
+msgid "Memdoc stopped"
+msgstr ""
+
+msgid "Memdoc started"
+msgstr ""
+
+msgid "Toggle failed: "
+msgstr ""
+
+msgid "Auto hide notifications "
+msgstr ""
+
+msgid "enabled"
+msgstr ""
+
+msgid "disabled"
+msgstr ""
+
+msgid "Settings update failed: "
+msgstr ""
+
+msgid "URL is empty"
+msgstr ""
+
+msgid "Invalid URL"
+msgstr ""
+
+msgid "URL saved"
+msgstr ""
+
+msgid "No changes detected"
+msgstr ""
+
+msgid "Update failed"
+msgstr ""
+
+msgid "updated"
+msgstr ""
+
+msgid "Config updated"
+msgstr ""
+
+msgid "Sing-Box reloaded"
+msgstr ""
+
+msgid "Save URL failed: "
+msgstr ""
+
+msgid "Update failed: "
+msgstr ""
+
+msgid "Editor not ready"
+msgstr ""
+
+msgid "Nothing to format"
+msgstr ""
+
+msgid "Formatted"
+msgstr ""
+
+msgid "Format config"
+msgstr ""
+
+msgid "validates and reorders keys per schema."
+msgstr ""
+
+msgid "fixes indentation, preserves comments and key order."
+msgstr ""
+
+msgid "Config is empty"
+msgstr ""
+
+msgid "Config saved"
+msgstr ""
+
+msgid "Save failed: "
+msgstr ""
+
+msgid "is now main config"
+msgstr ""
+
+msgid "Set as main failed: "
+msgstr ""
+
+msgid "Clear all data?"
+msgstr ""
+
+msgid "Config and URL for"
+msgstr ""
+
+msgid "will be erased."
+msgstr ""
+
+msgid "This cannot be undone."
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Config cleared, services stopped"
+msgstr ""
+
+msgid "cleared"
+msgstr ""
+
+msgid "Clear failed: "
+msgstr ""
+
+msgid "Switching mode\u2026"
+msgstr ""
+
+msgid "Mode switched, reloading\u2026"
+msgstr ""
+
+msgid "Mode switch failed: "
+msgstr ""
+
+msgid "Switch to tproxy mode?"
+msgstr ""
+
+msgid "tun interface"
+msgstr ""
+
+msgid "will be removed."
+msgstr ""
+
+msgid "tproxy nft rules and policy routing will be applied."
+msgstr ""
+
+msgid "Switch to tproxy"
+msgstr ""
+
+msgid "Switch to tun mode?"
+msgstr ""
+
+msgid "tproxy nft rules will be removed."
+msgstr ""
+
+msgid "and firewall zone will be configured."
+msgstr ""
+
+msgid "Switch to tun"
+msgstr ""
+
+msgid "Conflict: tproxy + tun both active"
+msgstr ""
+
+msgid "Both modes are active simultaneously. Disable one to resolve:"
+msgstr ""
+
+msgid "Keep tproxy (disable tun)"
+msgstr ""
+
+msgid "Keep tun (disable tproxy)"
+msgstr ""
+
+msgid "Updated"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Editor failed to load: "
+msgstr ""
+
+msgid "Page init failed: "
+msgstr ""
+
+msgid "Config error: "
+msgstr ""
+
+msgid "validation failed"
+msgstr ""
+
+msgid "Validation error: "
+msgstr ""
+
+msgid "Format failed: "
+msgstr ""
+
+msgid "unknown error"
+msgstr ""
+
+msgid "Format error: "
+msgstr ""

--- a/luci-app-singbox-ui/po/ru/singbox-ui.po
+++ b/luci-app-singbox-ui/po/ru/singbox-ui.po
@@ -1,0 +1,355 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Main Config #1"
+msgstr "Основная конфигурация #1"
+
+msgid "Backup Config #2"
+msgstr "Резервная конфигурация #2"
+
+msgid "Backup Config #3"
+msgstr "Резервная конфигурация #3"
+
+msgid "Running"
+msgstr "Работает"
+
+msgid "Error"
+msgstr "Ошибка"
+
+msgid "Inactive"
+msgstr "Неактивен"
+
+msgid "Stop"
+msgstr "Остановить"
+
+msgid "Start"
+msgstr "Запустить"
+
+msgid "Stop "
+msgstr "Остановить "
+
+msgid "Start "
+msgstr "Запустить "
+
+msgid "Sing-Box & Health Autoupdater"
+msgstr "Sing-Box и автообновлятор с проверкой"
+
+msgid "Sing-Box & Autoupdater"
+msgstr "Sing-Box и автообновлятор"
+
+msgid "Sing-Box"
+msgstr "Sing-Box"
+
+msgid "Restart"
+msgstr "Перезапустить"
+
+msgid "Stop Autoupdater"
+msgstr "Остановить автообновлятор"
+
+msgid "Autoupdater"
+msgstr "Автообновлятор"
+
+msgid "Stop periodic config update from subscription URL"
+msgstr "Остановить периодическое обновление конфигурации по URL подписки"
+
+msgid "Start periodic config update from subscription URL"
+msgstr "Запустить периодическое обновление конфигурации по URL подписки"
+
+msgid "Stop Health Autoupdater"
+msgstr "Остановить автообновлятор с проверкой"
+
+msgid "Health Autoupdater"
+msgstr "Автообновлятор с проверкой"
+
+msgid "Stop config update on outbound health failure"
+msgstr "Остановить обновление конфигурации при сбое проверки исходящего трафика"
+
+msgid "Update config when outbound health check fails"
+msgstr "Обновлять конфигурацию при сбое проверки исходящего трафика"
+
+msgid "Stop Memdoc"
+msgstr "Остановить монитор памяти"
+
+msgid "Memdoc"
+msgstr "Монитор памяти"
+
+msgid "Stop memory monitor"
+msgstr "Остановить монитор памяти"
+
+msgid "Restart sing-box when free RAM is low"
+msgstr "Перезапускать sing-box при нехватке памяти"
+
+msgid "Auto Hide Notif"
+msgstr "Автоскрытие уведомлений"
+
+msgid "Success: 6s, Error: 10s"
+msgstr "Успех: 6с, Ошибка: 10с"
+
+msgid "custom setup"
+msgstr "пользовательский режим"
+
+msgid "fix: tproxy + tun conflict"
+msgstr "исправить: конфликт tproxy + tun"
+
+msgid "mode"
+msgstr "режим"
+
+msgid "Dashboard"
+msgstr "Панель управления"
+
+msgid "Control"
+msgstr "Управление"
+
+msgid "Services"
+msgstr "Службы"
+
+msgid "Settings"
+msgstr "Настройки"
+
+msgid "Config"
+msgstr "Конфигурация"
+
+msgid "Logs"
+msgstr "Журналы"
+
+msgid "Subscription URL"
+msgstr "URL подписки"
+
+msgid "Save URL"
+msgstr "Сохранить URL"
+
+msgid "Update"
+msgstr "Обновить"
+
+msgid "Format"
+msgstr "Форматировать"
+
+msgid "Save"
+msgstr "Сохранить"
+
+msgid "Set as Main"
+msgstr "Сделать основной"
+
+msgid "Clear All"
+msgstr "Очистить всё"
+
+msgid "Scroll to bottom"
+msgstr "Прокрутить вниз"
+
+msgid "Bottom"
+msgstr "Вниз"
+
+msgid "Sing-Box stopped"
+msgstr "Sing-Box остановлен"
+
+msgid "Sing-Box started"
+msgstr "Sing-Box запущен"
+
+msgid "Operation failed: "
+msgstr "Операция не удалась: "
+
+msgid "Sing-Box restarted"
+msgstr "Sing-Box перезапущен"
+
+msgid "Restart failed: "
+msgstr "Перезапуск не удался: "
+
+msgid "Autoupdater stopped"
+msgstr "Автообновлятор остановлен"
+
+msgid "Autoupdater started"
+msgstr "Автообновлятор запущен"
+
+msgid "Health Autoupdater stopped"
+msgstr "Автообновлятор с проверкой остановлен"
+
+msgid "Health Autoupdater started"
+msgstr "Автообновлятор с проверкой запущен"
+
+msgid "Memdoc stopped"
+msgstr "Монитор памяти остановлен"
+
+msgid "Memdoc started"
+msgstr "Монитор памяти запущен"
+
+msgid "Toggle failed: "
+msgstr "Переключение не удалось: "
+
+msgid "Auto hide notifications "
+msgstr "Автоскрытие уведомлений "
+
+msgid "enabled"
+msgstr "включено"
+
+msgid "disabled"
+msgstr "отключено"
+
+msgid "Settings update failed: "
+msgstr "Обновление настроек не удалось: "
+
+msgid "URL is empty"
+msgstr "URL пуст"
+
+msgid "Invalid URL"
+msgstr "Неверный URL"
+
+msgid "URL saved"
+msgstr "URL сохранён"
+
+msgid "No changes detected"
+msgstr "Изменений не обнаружено"
+
+msgid "Update failed"
+msgstr "Обновление не удалось"
+
+msgid "updated"
+msgstr "обновлено"
+
+msgid "Config updated"
+msgstr "Конфигурация обновлена"
+
+msgid "Sing-Box reloaded"
+msgstr "Sing-Box перезагружен"
+
+msgid "Save URL failed: "
+msgstr "Сохранение URL не удалось: "
+
+msgid "Update failed: "
+msgstr "Обновление не удалось: "
+
+msgid "Editor not ready"
+msgstr "Редактор не готов"
+
+msgid "Nothing to format"
+msgstr "Нечего форматировать"
+
+msgid "Formatted"
+msgstr "Отформатировано"
+
+msgid "Format config"
+msgstr "Форматировать конфигурацию"
+
+msgid "validates and reorders keys per schema."
+msgstr "проверяет и переупорядочивает ключи по схеме."
+
+msgid "fixes indentation, preserves comments and key order."
+msgstr "исправляет отступы, сохраняет комментарии и порядок ключей."
+
+msgid "Config is empty"
+msgstr "Конфигурация пуста"
+
+msgid "Config saved"
+msgstr "Конфигурация сохранена"
+
+msgid "Save failed: "
+msgstr "Сохранение не удалось: "
+
+msgid "is now main config"
+msgstr "теперь основная конфигурация"
+
+msgid "Set as main failed: "
+msgstr "Установка основной конфигурации не удалась: "
+
+msgid "Clear all data?"
+msgstr "Очистить все данные?"
+
+msgid "Config and URL for"
+msgstr "Конфигурация и URL для"
+
+msgid "will be erased."
+msgstr "будут удалены."
+
+msgid "This cannot be undone."
+msgstr "Это действие необратимо."
+
+msgid "Clear"
+msgstr "Очистить"
+
+msgid "Config cleared, services stopped"
+msgstr "Конфигурация очищена, службы остановлены"
+
+msgid "cleared"
+msgstr "очищено"
+
+msgid "Clear failed: "
+msgstr "Очистка не удалась: "
+
+msgid "Switching mode\u2026"
+msgstr "Переключение режима\u2026"
+
+msgid "Mode switched, reloading\u2026"
+msgstr "Режим переключён, перезагрузка\u2026"
+
+msgid "Mode switch failed: "
+msgstr "Переключение режима не удалось: "
+
+msgid "Switch to tproxy mode?"
+msgstr "Переключиться в режим tproxy?"
+
+msgid "tun interface"
+msgstr "интерфейс tun"
+
+msgid "will be removed."
+msgstr "будет удалён."
+
+msgid "tproxy nft rules and policy routing will be applied."
+msgstr "Будут применены правила nft tproxy и политика маршрутизации."
+
+msgid "Switch to tproxy"
+msgstr "Переключиться на tproxy"
+
+msgid "Switch to tun mode?"
+msgstr "Переключиться в режим tun?"
+
+msgid "tproxy nft rules will be removed."
+msgstr "Правила nft tproxy будут удалены."
+
+msgid "and firewall zone will be configured."
+msgstr "и будет настроена зона брандмауэра."
+
+msgid "Switch to tun"
+msgstr "Переключиться на tun"
+
+msgid "Conflict: tproxy + tun both active"
+msgstr "Конфликт: tproxy и tun активны одновременно"
+
+msgid "Both modes are active simultaneously. Disable one to resolve:"
+msgstr "Оба режима активны одновременно. Отключите один для устранения:"
+
+msgid "Keep tproxy (disable tun)"
+msgstr "Оставить tproxy (отключить tun)"
+
+msgid "Keep tun (disable tproxy)"
+msgstr "Оставить tun (отключить tproxy)"
+
+msgid "Updated"
+msgstr "Обновлено"
+
+msgid "Cancel"
+msgstr "Отмена"
+
+msgid "Editor failed to load: "
+msgstr "Не удалось загрузить редактор: "
+
+msgid "Page init failed: "
+msgstr "Ошибка инициализации страницы: "
+
+msgid "Config error: "
+msgstr "Ошибка конфигурации: "
+
+msgid "validation failed"
+msgstr "проверка не прошла"
+
+msgid "Validation error: "
+msgstr "Ошибка проверки: "
+
+msgid "Format failed: "
+msgstr "Форматирование не удалось: "
+
+msgid "unknown error"
+msgstr "неизвестная ошибка"
+
+msgid "Format error: "
+msgstr "Ошибка форматирования: "

--- a/luci-app-singbox-ui/po/zh_Hans/singbox-ui.po
+++ b/luci-app-singbox-ui/po/zh_Hans/singbox-ui.po
@@ -1,0 +1,355 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Main Config #1"
+msgstr "主配置 #1"
+
+msgid "Backup Config #2"
+msgstr "备用配置 #2"
+
+msgid "Backup Config #3"
+msgstr "备用配置 #3"
+
+msgid "Running"
+msgstr "运行中"
+
+msgid "Error"
+msgstr "错误"
+
+msgid "Inactive"
+msgstr "未激活"
+
+msgid "Stop"
+msgstr "停止"
+
+msgid "Start"
+msgstr "启动"
+
+msgid "Stop "
+msgstr "停止 "
+
+msgid "Start "
+msgstr "启动 "
+
+msgid "Sing-Box & Health Autoupdater"
+msgstr "Sing-Box & 健康自动更新器"
+
+msgid "Sing-Box & Autoupdater"
+msgstr "Sing-Box & 自动更新器"
+
+msgid "Sing-Box"
+msgstr "Sing-Box"
+
+msgid "Restart"
+msgstr "重启"
+
+msgid "Stop Autoupdater"
+msgstr "停止自动更新器"
+
+msgid "Autoupdater"
+msgstr "自动更新器"
+
+msgid "Stop periodic config update from subscription URL"
+msgstr "停止从订阅 URL 定期更新配置"
+
+msgid "Start periodic config update from subscription URL"
+msgstr "从订阅 URL 定期更新配置"
+
+msgid "Stop Health Autoupdater"
+msgstr "停止健康自动更新器"
+
+msgid "Health Autoupdater"
+msgstr "健康自动更新器"
+
+msgid "Stop config update on outbound health failure"
+msgstr "停止出站健康检查失败时的配置更新"
+
+msgid "Update config when outbound health check fails"
+msgstr "出站健康检查失败时更新配置"
+
+msgid "Stop Memdoc"
+msgstr "停止内存监控"
+
+msgid "Memdoc"
+msgstr "内存监控"
+
+msgid "Stop memory monitor"
+msgstr "停止内存监控器"
+
+msgid "Restart sing-box when free RAM is low"
+msgstr "内存不足时重启 sing-box"
+
+msgid "Auto Hide Notif"
+msgstr "自动隐藏通知"
+
+msgid "Success: 6s, Error: 10s"
+msgstr "成功: 6秒, 错误: 10秒"
+
+msgid "custom setup"
+msgstr "自定义模式"
+
+msgid "fix: tproxy + tun conflict"
+msgstr "修复: tproxy + tun 冲突"
+
+msgid "mode"
+msgstr "模式"
+
+msgid "Dashboard"
+msgstr "面板"
+
+msgid "Control"
+msgstr "控制"
+
+msgid "Services"
+msgstr "服务"
+
+msgid "Settings"
+msgstr "设置"
+
+msgid "Config"
+msgstr "配置"
+
+msgid "Logs"
+msgstr "日志"
+
+msgid "Subscription URL"
+msgstr "订阅 URL"
+
+msgid "Save URL"
+msgstr "保存 URL"
+
+msgid "Update"
+msgstr "更新"
+
+msgid "Format"
+msgstr "格式化"
+
+msgid "Save"
+msgstr "保存"
+
+msgid "Set as Main"
+msgstr "设为主配置"
+
+msgid "Clear All"
+msgstr "清除全部"
+
+msgid "Scroll to bottom"
+msgstr "滚动到底部"
+
+msgid "Bottom"
+msgstr "底部"
+
+msgid "Sing-Box stopped"
+msgstr "Sing-Box 已停止"
+
+msgid "Sing-Box started"
+msgstr "Sing-Box 已启动"
+
+msgid "Operation failed: "
+msgstr "操作失败: "
+
+msgid "Sing-Box restarted"
+msgstr "Sing-Box 已重启"
+
+msgid "Restart failed: "
+msgstr "重启失败: "
+
+msgid "Autoupdater stopped"
+msgstr "自动更新器已停止"
+
+msgid "Autoupdater started"
+msgstr "自动更新器已启动"
+
+msgid "Health Autoupdater stopped"
+msgstr "健康自动更新器已停止"
+
+msgid "Health Autoupdater started"
+msgstr "健康自动更新器已启动"
+
+msgid "Memdoc stopped"
+msgstr "内存监控已停止"
+
+msgid "Memdoc started"
+msgstr "内存监控已启动"
+
+msgid "Toggle failed: "
+msgstr "切换失败: "
+
+msgid "Auto hide notifications "
+msgstr "自动隐藏通知 "
+
+msgid "enabled"
+msgstr "已启用"
+
+msgid "disabled"
+msgstr "已禁用"
+
+msgid "Settings update failed: "
+msgstr "设置更新失败: "
+
+msgid "URL is empty"
+msgstr "URL 为空"
+
+msgid "Invalid URL"
+msgstr "无效的 URL"
+
+msgid "URL saved"
+msgstr "URL 已保存"
+
+msgid "No changes detected"
+msgstr "未检测到更改"
+
+msgid "Update failed"
+msgstr "更新失败"
+
+msgid "updated"
+msgstr "已更新"
+
+msgid "Config updated"
+msgstr "配置已更新"
+
+msgid "Sing-Box reloaded"
+msgstr "Sing-Box 已重载"
+
+msgid "Save URL failed: "
+msgstr "保存 URL 失败: "
+
+msgid "Update failed: "
+msgstr "更新失败: "
+
+msgid "Editor not ready"
+msgstr "编辑器未就绪"
+
+msgid "Nothing to format"
+msgstr "没有可格式化的内容"
+
+msgid "Formatted"
+msgstr "已格式化"
+
+msgid "Format config"
+msgstr "格式化配置"
+
+msgid "validates and reorders keys per schema."
+msgstr "按 schema 验证并重新排列键。"
+
+msgid "fixes indentation, preserves comments and key order."
+msgstr "修复缩进，保留注释和键顺序。"
+
+msgid "Config is empty"
+msgstr "配置为空"
+
+msgid "Config saved"
+msgstr "配置已保存"
+
+msgid "Save failed: "
+msgstr "保存失败: "
+
+msgid "is now main config"
+msgstr "已设为主配置"
+
+msgid "Set as main failed: "
+msgstr "设为主配置失败: "
+
+msgid "Clear all data?"
+msgstr "清除所有数据？"
+
+msgid "Config and URL for"
+msgstr "配置和 URL 中的"
+
+msgid "will be erased."
+msgstr "将被清除。"
+
+msgid "This cannot be undone."
+msgstr "此操作不可撤销。"
+
+msgid "Clear"
+msgstr "清除"
+
+msgid "Config cleared, services stopped"
+msgstr "配置已清除，服务已停止"
+
+msgid "cleared"
+msgstr "已清除"
+
+msgid "Clear failed: "
+msgstr "清除失败: "
+
+msgid "Switching mode\u2026"
+msgstr "正在切换模式\u2026"
+
+msgid "Mode switched, reloading\u2026"
+msgstr "模式已切换，正在重载\u2026"
+
+msgid "Mode switch failed: "
+msgstr "模式切换失败: "
+
+msgid "Switch to tproxy mode?"
+msgstr "切换到 tproxy 模式？"
+
+msgid "tun interface"
+msgstr "tun 接口"
+
+msgid "will be removed."
+msgstr "将被移除。"
+
+msgid "tproxy nft rules and policy routing will be applied."
+msgstr "将应用 tproxy nft 规则和策略路由。"
+
+msgid "Switch to tproxy"
+msgstr "切换到 tproxy"
+
+msgid "Switch to tun mode?"
+msgstr "切换到 tun 模式？"
+
+msgid "tproxy nft rules will be removed."
+msgstr "tproxy nft 规则将被移除。"
+
+msgid "and firewall zone will be configured."
+msgstr "并配置防火墙区域。"
+
+msgid "Switch to tun"
+msgstr "切换到 tun"
+
+msgid "Conflict: tproxy + tun both active"
+msgstr "冲突: tproxy + tun 同时激活"
+
+msgid "Both modes are active simultaneously. Disable one to resolve:"
+msgstr "两种模式同时激活，请禁用其中一个以解决冲突："
+
+msgid "Keep tproxy (disable tun)"
+msgstr "保留 tproxy（禁用 tun）"
+
+msgid "Keep tun (disable tproxy)"
+msgstr "保留 tun（禁用 tproxy）"
+
+msgid "Updated"
+msgstr "已更新"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Editor failed to load: "
+msgstr "编辑器加载失败: "
+
+msgid "Page init failed: "
+msgstr "页面初始化失败: "
+
+msgid "Config error: "
+msgstr "配置错误: "
+
+msgid "validation failed"
+msgstr "验证失败"
+
+msgid "Validation error: "
+msgstr "验证错误: "
+
+msgid "Format failed: "
+msgstr "格式化失败: "
+
+msgid "unknown error"
+msgstr "未知错误"
+
+msgid "Format error: "
+msgstr "格式化错误: "

--- a/luci-app-singbox-ui/root/usr/share/luci/menu.d/luci-app-singbox-ui.json
+++ b/luci-app-singbox-ui/root/usr/share/luci/menu.d/luci-app-singbox-ui.json
@@ -9,10 +9,7 @@
         "depends": {
             "acl": [
                 "luci-app-singbox-ui"
-            ],
-            "uci": {
-                "singbox-ui": true
-            }
+            ]
         }
     }
 }

--- a/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singbox-ui.json
+++ b/luci-app-singbox-ui/root/usr/share/rpcd/acl.d/luci-app-singbox-ui.json
@@ -2,6 +2,7 @@
     "luci-app-singbox-ui": {
         "description": "Singbox-UI management access",
         "read": {
+            "session": ["access"],
             "file": {
                 "/etc/init.d/sing-box": ["exec"],
                 "/etc/init.d/singbox-ui-autoupdater-service": ["exec"],


### PR DESCRIPTION
## Summary

### Internationalization (i18n)
- Wrap all user-visible strings in `singbox-ui.js` with `_()` for LuCI translation support
- Add `po/` translation files for **zh_Hans** (Chinese Simplified), **en** (English), and **ru** (Russian)

### Bug Fixes
- **ACL**: Add `session` read permission to `luci-app-singbox-ui.json` — prevents 403 errors when LuCI session API is called
- **Menu**: Remove unnecessary `uci` dependency from `luci-app-singbox-ui.json` — fixes menu not appearing when UCI config is absent

### Makefile Cleanup
- Remove redundant `LUCI_LANGUAGES` and `LUCI_LANG.*` declarations — `luci.mk` auto-discovers languages from `po/` subdirectories, making these declarations unnecessary